### PR TITLE
Integration test, signature from secret_toolkit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
 [[package]]
 name = "secret-toolkit"
 version = "0.1.0"
-source = "git+https://github.com/enigmampc/secret-toolkit?rev=aa99d21#aa99d210a354b0af70d7c1234224459603067cf3"
+source = "git+https://github.com/enigmampc/secret-toolkit?rev=faac40d#faac40dbadb97e463270318d41af07297b81ce04"
 dependencies = [
  "secret-toolkit-crypto",
  "secret-toolkit-serialization",
@@ -403,7 +403,7 @@ dependencies = [
 [[package]]
 name = "secret-toolkit-crypto"
 version = "0.1.0"
-source = "git+https://github.com/enigmampc/secret-toolkit?rev=aa99d21#aa99d210a354b0af70d7c1234224459603067cf3"
+source = "git+https://github.com/enigmampc/secret-toolkit?rev=faac40d#faac40dbadb97e463270318d41af07297b81ce04"
 dependencies = [
  "cosmwasm-std",
  "libsecp256k1",
@@ -415,7 +415,7 @@ dependencies = [
 [[package]]
 name = "secret-toolkit-serialization"
 version = "0.1.0"
-source = "git+https://github.com/enigmampc/secret-toolkit?rev=aa99d21#aa99d210a354b0af70d7c1234224459603067cf3"
+source = "git+https://github.com/enigmampc/secret-toolkit?rev=faac40d#faac40dbadb97e463270318d41af07297b81ce04"
 dependencies = [
  "bincode2",
  "cosmwasm-std",
@@ -425,7 +425,7 @@ dependencies = [
 [[package]]
 name = "secret-toolkit-storage"
 version = "0.1.0"
-source = "git+https://github.com/enigmampc/secret-toolkit?rev=aa99d21#aa99d210a354b0af70d7c1234224459603067cf3"
+source = "git+https://github.com/enigmampc/secret-toolkit?rev=faac40d#faac40dbadb97e463270318d41af07297b81ce04"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "secret-toolkit-utils"
 version = "0.1.0"
-source = "git+https://github.com/enigmampc/secret-toolkit?rev=aa99d21#aa99d210a354b0af70d7c1234224459603067cf3"
+source = "git+https://github.com/enigmampc/secret-toolkit?rev=faac40d#faac40dbadb97e463270318d41af07297b81ce04"
 dependencies = [
  "cosmwasm-std",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,4 @@ libsecp256k1 = { version = "0.3.5", default-features = false, features = ["hmac"
 rand_chacha = { version = "0.2.2", default-features = false }
 rand_core = { version =  "0.5.1", default-features = false }
 hex = {version = "0.4.2", default-features = false }
-secret-toolkit = { git = "https://github.com/enigmampc/secret-toolkit", rev = "aa99d21" }
+secret-toolkit = { git = "https://github.com/enigmampc/secret-toolkit", rev = "faac40d" }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -41,15 +41,15 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
 
             let key_id = generate_key_id(&env);
 
-            let api_key: String = generate_api_key(&seed, &env);
+            let api_key = generate_api_key(&seed, &env);
 
             let private_key = generate_private_key(&env, &seed, &key_seed.into_bytes());
 
             store_key_record(
                 &mut (deps.storage),
-                key_id.to_string(),
+                &key_id,
                 private_key,
-                api_key.to_string(),
+                api_key.clone(),
                 passphrase,
             );
 
@@ -73,22 +73,19 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
             let record = get_key_record(&mut (deps.storage), &key_id)?;
 
             if !authenticate_request(&record, &api_key, &passphrase) {
-                return Err(StdError::GenericErr {
-                    msg: "Unauthorized. Bad API key or passphrase".to_string(),
-                    backtrace: None,
-                });
+                return Err(StdError::generic_err(
+                    "Unauthorized. Bad API key or passphrase",
+                ));
             }
 
-            let data_bytes = hex::decode(data).map_err(|_| StdError::GenericErr {
-                msg: "Error validating data format: should be hex string".to_string(),
-                backtrace: None,
+            let data_bytes = hex::decode(data).map_err(|_| {
+                StdError::generic_err("Error validating data format: should be hex string")
             })?;
 
             if !validate_data_len(&data_bytes) {
-                return Err(StdError::GenericErr {
-                    msg: "Error validating data size: Should be 64 characters".to_string(),
-                    backtrace: None,
-                });
+                return Err(StdError::generic_err(
+                    "Error validating data size: Should be 64 characters",
+                ));
             }
 
             let mut data_arr = [0u8; 32];
@@ -107,7 +104,7 @@ pub fn query<S: Storage, A: Api, Q: Querier>(
     _deps: &Extern<S, A, Q>,
     _msg: QueryMsg,
 ) -> StdResult<Binary> {
-    Err(StdError::generic_err("Queries are not supported yet:)"))
+    Err(StdError::generic_err("Queries are not supported yet :)"))
 }
 
 /////////////////////////////// Migrate ///////////////////////////////
@@ -120,9 +117,7 @@ pub fn migrate<S: Storage, A: Api, Q: Querier>(
     _env: Env,
     _msg: MigrateMsg,
 ) -> StdResult<MigrateResponse> {
-    Err(StdError::generic_err(
-        "You can only use this contract for migrations",
-    ))
+    Err(StdError::generic_err("You can not migrate this contract"))
 }
 
 #[cfg(test)]

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -50,7 +50,7 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
                 key_id.to_string(),
                 private_key,
                 api_key.to_string(),
-                passphrase.to_string(),
+                passphrase,
             );
 
             let public_key = pubkey(&private_key).serialize_compressed();
@@ -94,9 +94,7 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
             let mut data_arr = [0u8; 32];
             data_arr.copy_from_slice(&data_bytes);
 
-            let signature = PrivateKey::parse(&record.key)?
-                .sign(&data_arr)
-                .serialize();
+            let signature = PrivateKey::parse(&record.key)?.sign(&data_arr).serialize();
 
             SignResponse { signature }.into()
         }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -6,7 +6,6 @@ use secret_toolkit::crypto::secp256k1::PrivateKey;
 
 use crate::msg::{HandleMsg, InitMsg, MigrateMsg, QueryMsg};
 use crate::responses::{CreateKeyResponse, SignResponse};
-use crate::sign::pubkey;
 use crate::state::{get_key_record, get_seed, store_key_record, store_seed};
 use crate::utils::{
     authenticate_request, generate_api_key, generate_key_id, generate_private_key, generate_seed,
@@ -53,7 +52,9 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
                 passphrase,
             );
 
-            let public_key = pubkey(&private_key).serialize_compressed();
+            let public_key = PrivateKey::parse(&private_key)?
+                .pubkey()
+                .serialize_compressed();
 
             CreateKeyResponse {
                 api_key,

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -47,10 +47,10 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
 
             store_key_record(
                 &mut (deps.storage),
-                &key_id,
+                key_id.to_string(),
                 private_key,
-                &api_key,
-                &passphrase,
+                api_key.to_string(),
+                passphrase.to_string(),
             );
 
             let public_key = pubkey(&private_key).serialize_compressed();
@@ -94,11 +94,9 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
             let mut data_arr = [0u8; 32];
             data_arr.copy_from_slice(&data_bytes);
 
-            let signature = PrivateKey::parse(&record.key)
-                .unwrap()
+            let signature = PrivateKey::parse(&record.key)?
                 .sign(&data_arr)
                 .serialize();
-            //           let signature = sign(&record.key, &data_arr).serialize();
 
             SignResponse { signature }.into()
         }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -142,9 +142,7 @@ mod tests {
         let env = mock_env("creator", &coins(1000, "earth"));
         // we can just call .unwrap() to assert this was a success
         let res = init(&mut deps, env, msg);
-        match res.unwrap() {
-            InitResponse => {}
-        }
+        println!("{:?}", res.unwrap()); 
     }
 
     #[test]
@@ -157,9 +155,7 @@ mod tests {
         let env = mock_env("creator", &coins(1000, "earth"));
         // we can just call .unwrap() to assert this was a success
         let res = init(&mut deps, env, msg);
-        match res.unwrap() {
-            InitResponse => {}
-        }
+        println!("{:?}", res.unwrap());
 
         let msg = HandleMsg::NewKey {
             key_seed: "test".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod contract;
 pub mod msg;
 mod responses;
-mod sign;
 mod state;
 mod utils;
 

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -1,7 +1,5 @@
 use cosmwasm_std::{log, HandleResponse};
 
-use hex;
-
 #[derive(Clone)]
 pub struct CreateKeyResponse {
     pub key_id: String,

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,5 +1,3 @@
-use secp256k1;
-
 pub fn pubkey(priv_key: &[u8; 32]) -> secp256k1::PublicKey {
     let pk = secp256k1::SecretKey::parse(priv_key).unwrap();
     secp256k1::PublicKey::from_secret_key(&pk)

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -4,33 +4,3 @@ pub fn pubkey(priv_key: &[u8; 32]) -> secp256k1::PublicKey {
     let pk = secp256k1::SecretKey::parse(priv_key).unwrap();
     secp256k1::PublicKey::from_secret_key(&pk)
 }
-
-pub fn sign(priv_key: &[u8; 32], data: &[u8; 32]) -> secp256k1::Signature {
-    let pk = secp256k1::SecretKey::parse(priv_key).unwrap();
-
-    let msg = secp256k1::Message::parse(data);
-
-    let sig = secp256k1::sign(&msg, &pk);
-
-    sig.0
-}
-
-// pub fn encrypt(priv_key: &[u8; 32], data: &[u8]) -> secp256k1::Signature {
-//     let pk = secp256k1::SecretKey::parse(priv_key).unwrap();
-//
-//     let msg = secp256k1::Message::parse(data);
-//
-//     let sig = secp256k1::sign(&msg, &pk);
-//
-//     sig.0
-// }
-
-// pub fn decrypt(priv_key: &[u8; 32], data: &[u8]) -> secp256k1::Signature {
-//     let pk = secp256k1::SecretKey::parse(priv_key).unwrap();
-//
-//     let msg = secp256k1::Message::parse(data);
-//
-//     let sig = secp256k1::sign(&msg, &pk);
-//
-//     sig.0
-// }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,4 +1,0 @@
-pub fn pubkey(priv_key: &[u8; 32]) -> secp256k1::PublicKey {
-    let pk = secp256k1::SecretKey::parse(priv_key).unwrap();
-    secp256k1::PublicKey::from_secret_key(&pk)
-}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{StdError, StdResult, Storage};
 use serde::{Deserialize, Serialize};
 
-pub const SEED_KEY: &[u8] = "seed".as_bytes();
+pub const SEED_KEY: &[u8] = b"seed";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct PrivateKeyRecord {
@@ -20,14 +20,14 @@ pub fn get_seed<S: Storage>(storage: &mut S) -> Vec<u8> {
 
 pub fn store_key_record<S: Storage>(
     storage: &mut S,
-    key_id: &String,
+    key_id: &str,
     private_key: [u8; 32],
-    api_key: &String,
-    passphrase: &String,
+    api_key: &str,
+    passphrase: &str,
 ) {
     let record = PrivateKeyRecord {
-        api_key: api_key.clone(),
-        passphrase: passphrase.clone(),
+        api_key: api_key.to_string(),
+        passphrase: passphrase.to_string(),
         key: private_key,
     };
 
@@ -36,7 +36,7 @@ pub fn store_key_record<S: Storage>(
     storage.set(&key_id.as_bytes(), record_bytes.as_slice());
 }
 
-pub fn get_key_record<S: Storage>(storage: &mut S, key_id: &String) -> StdResult<PrivateKeyRecord> {
+pub fn get_key_record<S: Storage>(storage: &mut S, key_id: &str) -> StdResult<PrivateKeyRecord> {
     if let Some(record_bytes) = storage.get(&key_id.as_bytes()) {
         let record: PrivateKeyRecord = bincode2::deserialize(&record_bytes).unwrap();
         Ok(record)

--- a/src/state.rs
+++ b/src/state.rs
@@ -20,7 +20,7 @@ pub fn get_seed<S: Storage>(storage: &mut S) -> Vec<u8> {
 
 pub fn store_key_record<S: Storage>(
     storage: &mut S,
-    key_id: String,
+    key_id: &str,
     private_key: [u8; 32],
     api_key: String,
     passphrase: String,
@@ -33,7 +33,7 @@ pub fn store_key_record<S: Storage>(
 
     let record_bytes: Vec<u8> = bincode2::serialize(&record).unwrap();
 
-    storage.set(&key_id.as_bytes(), record_bytes.as_slice());
+    storage.set(key_id.as_bytes(), record_bytes.as_slice());
 }
 
 pub fn get_key_record<S: Storage>(storage: &mut S, key_id: &str) -> StdResult<PrivateKeyRecord> {
@@ -41,9 +41,6 @@ pub fn get_key_record<S: Storage>(storage: &mut S, key_id: &str) -> StdResult<Pr
         let record: PrivateKeyRecord = bincode2::deserialize(&record_bytes).unwrap();
         Ok(record)
     } else {
-        Err(StdError::GenericErr {
-            msg: "Key ID not found".to_string(),
-            backtrace: None,
-        })
+        Err(StdError::generic_err("Key ID not found"))
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -20,10 +20,10 @@ pub fn get_seed<S: Storage>(storage: &mut S) -> Vec<u8> {
 
 pub fn store_key_record<S: Storage>(
     storage: &mut S,
-    key_id: &str,
+    key_id: String,
     private_key: [u8; 32],
-    api_key: &str,
-    passphrase: &str,
+    api_key: String,
+    passphrase: String,
 ) {
     let record = PrivateKeyRecord {
         api_key: api_key.to_string(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,8 +26,8 @@ pub fn store_key_record<S: Storage>(
     passphrase: String,
 ) {
     let record = PrivateKeyRecord {
-        api_key: api_key.to_string(),
-        passphrase: passphrase.to_string(),
+        api_key,
+        passphrase,
         key: private_key,
     };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,19 +15,15 @@ pub fn generate_api_key(seed: &[u8], env: &Env) -> String {
     format!("api_key_{}", base64::encode(rng.rand_bytes()))
 }
 
-pub fn authenticate_request(
-    record: &PrivateKeyRecord,
-    api_key: &String,
-    passphrase: &String,
-) -> bool {
-    return &record.api_key == api_key && &record.passphrase == passphrase;
+pub fn authenticate_request(record: &PrivateKeyRecord, api_key: &str, passphrase: &str) -> bool {
+    record.api_key == api_key && record.passphrase == passphrase
 }
 
 pub fn validate_data_len(data: &[u8]) -> bool {
     data.len() == SHA256_HASH_SIZE
 }
 
-pub fn generate_seed(keying_material: &String) -> [u8; 32] {
+pub fn generate_seed(keying_material: &str) -> [u8; 32] {
     sha_256(&keying_material.as_bytes())
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -50,36 +50,27 @@ fn init_sign() {
     let env = mock_env("creator", &coins(1000, "earth"));
     let res = handle(&mut deps, env, msg);
     let new_key_res = res.unwrap();
-    let api_key = match get_log_attribute(&new_key_res, "api_key".to_string()) {
-        Some(d) => d,
-        None => panic!("No api key detected"),
-    };
-    let key_id = match get_log_attribute(&new_key_res, "key_id".to_string()) {
-        Some(d) => d,
-        None => panic!("No key id detected"),
-    };
+    let api_key = get_log_attribute(&new_key_res, "api_key").expect("No api key detected");
+    let key_id = get_log_attribute(&new_key_res, "key_id").expect("No key id detected");
 
     let msg = HandleMsg::Sign {
         passphrase: passphrase.to_string(),
-        api_key: api_key,
-        key_id: key_id,
         data: data.to_string(),
+        api_key,
+        key_id,
     };
     let env = mock_env("creator", &coins(1000, "earth"));
     let res = handle(&mut deps, env, msg);
     let sign_res = res.unwrap();
-    let signature = match get_log_attribute(&sign_res, "signature".to_string()) {
-        Some(d) => d,
-        None => panic!("No signature detected"),
-    };
+    let signature = get_log_attribute(&sign_res, "signature").expect("No signature detected"); 
 
     let expected_signature = "e3eb2ff3403a0dbb55253dc2039995eaf4932d92b55c8422f69b5b5e1f0753c15581f9c53e3987db54d6f3f04d8c9f32407652758456411a984f55d8c1c6097a";
     assert_eq!(signature, expected_signature);
 }
 
-fn get_log_attribute(resp: &HandleResponse, key: String) -> Option<String> {
+fn get_log_attribute(resp: &HandleResponse, key: &str) -> Option<String> {
     for log in resp.log.iter() {
-        if log.key == key {
+        if &log.key == key {
             return Some(log.value.to_owned());
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17,10 +17,10 @@
 //!      });
 //! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
-use cosmwasm_std::testing::{mock_env, mock_dependencies};
+use cosmwasm_std::testing::{mock_dependencies, mock_env};
 use cosmwasm_std::{coins, HandleResponse};
 
-use secret_vault::contract::{init, handle};
+use secret_vault::contract::{handle, init};
 use secret_vault::msg::{HandleMsg, InitMsg};
 
 // This line will test the output of cargo wasm
@@ -58,8 +58,8 @@ fn init_sign() {
         Some(d) => d,
         None => panic!("No key id detected"),
     };
-   
-    let msg = HandleMsg::Sign{
+
+    let msg = HandleMsg::Sign {
         passphrase: passphrase.to_string(),
         api_key: api_key,
         key_id: key_id,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17,76 +17,72 @@
 //!      });
 //! 4. Anywhere you see query(&deps, ...) you must replace it with query(&mut deps, ...)
 
-use cosmwasm_std::testing::{handle, init, mock_env, mock_instance, query};
-use cosmwasm_std::{coins, from_binary, HandleResponse, HandleResult, InitResponse, StdError};
+use cosmwasm_std::testing::{mock_env, mock_dependencies};
+use cosmwasm_std::{coins, HandleResponse};
 
-use secret_vault::msg::{CountResponse, HandleMsg, InitMsg, QueryMsg};
+use secret_vault::contract::{init, handle};
+use secret_vault::msg::{HandleMsg, InitMsg};
 
 // This line will test the output of cargo wasm
-static WASM: &[u8] = include_bytes!("../target/wasm32-unknown-unknown/release/secret_vault.wasm");
+//static WASM: &[u8] = include_bytes!("../target/wasm32-unknown-unknown/release/secret_vault.wasm");
 // You can uncomment this line instead to test productionified build from rust-optimizer
 // static WASM: &[u8] = include_bytes!("../contract.wasm");
 
 #[test]
-fn proper_initialization() {
-    let mut deps = mock_instance(WASM, &[]);
+fn init_sign() {
+    let mut deps = mock_dependencies(20, &[]);
+    let seed_phrase = "GX4CRn8cLOtaxWAduRKr";
+    let key_seed = "uI67K87zFSU3WKlXtiYK";
+    let passphrase = "mmSnja3rrA8J9NWImqOz";
+    let data = "674de7af309b691bc121e6f40a6c76a513883925f5358838fc5943db720a6e78";
 
-    let msg = InitMsg::Init { count: 17 };
+    let msg = InitMsg::Init {
+        seed_phrase: seed_phrase.to_string(),
+    };
     let env = mock_env("creator", &coins(1000, "earth"));
+    let res = init(&mut deps, env, msg);
+    println!("{:?}", res.unwrap());
 
-    // we can just call .unwrap() to assert this was a success
-    let res: InitResponse = init(&mut deps, env, msg).unwrap();
-    assert_eq!(res.messages.len(), 0);
+    let msg = HandleMsg::NewKey {
+        key_seed: key_seed.to_string(),
+        passphrase: passphrase.to_string(),
+    };
+    let env = mock_env("creator", &coins(1000, "earth"));
+    let res = handle(&mut deps, env, msg);
+    let new_key_res = res.unwrap();
+    let api_key = match get_log_attribute(&new_key_res, "api_key".to_string()) {
+        Some(d) => d,
+        None => panic!("No api key detected"),
+    };
+    let key_id = match get_log_attribute(&new_key_res, "key_id".to_string()) {
+        Some(d) => d,
+        None => panic!("No key id detected"),
+    };
+   
+    let msg = HandleMsg::Sign{
+        passphrase: passphrase.to_string(),
+        api_key: api_key,
+        key_id: key_id,
+        data: data.to_string(),
+    };
+    let env = mock_env("creator", &coins(1000, "earth"));
+    let res = handle(&mut deps, env, msg);
+    let sign_res = res.unwrap();
+    let signature = match get_log_attribute(&sign_res, "signature".to_string()) {
+        Some(d) => d,
+        None => panic!("No signature detected"),
+    };
 
-    // it worked, let's query the state
-    let res = query(&mut deps, QueryMsg::GetCount {}).unwrap();
-    let value: CountResponse = from_binary(&res).unwrap();
-    assert_eq!(value.count, 17);
+    let expected_signature = "e3eb2ff3403a0dbb55253dc2039995eaf4932d92b55c8422f69b5b5e1f0753c15581f9c53e3987db54d6f3f04d8c9f32407652758456411a984f55d8c1c6097a";
+    assert_eq!(signature, expected_signature);
 }
 
-#[test]
-fn increment() {
-    let mut deps = mock_instance(WASM, &coins(2, "token"));
-
-    let msg = InitMsg { count: 17 };
-    let env = mock_env("creator", &coins(2, "token"));
-    let _res: InitResponse = init(&mut deps, env, msg).unwrap();
-
-    // beneficiary can release it
-    let env = mock_env("anyone", &coins(2, "token"));
-    let msg = HandleMsg::Increment {};
-    let _res: HandleResponse = handle(&mut deps, env, msg).unwrap();
-
-    // should increase counter by 1
-    let res = query(&mut deps, QueryMsg::GetCount {}).unwrap();
-    let value: CountResponse = from_binary(&res).unwrap();
-    assert_eq!(value.count, 18);
-}
-
-#[test]
-fn reset() {
-    let mut deps = mock_instance(WASM, &coins(2, "token"));
-
-    let msg = InitMsg { count: 17 };
-    let env = mock_env(&deps.api, "creator", &coins(2, "token"));
-    let _res: InitResponse = init(&mut deps, env, msg).unwrap();
-
-    // beneficiary can release it
-    let unauth_env = mock_env(&deps.api, "anyone", &coins(2, "token"));
-    let msg = HandleMsg::Reset { count: 5 };
-    let res: HandleResult = handle(&mut deps, unauth_env, msg);
-    match res.unwrap_err() {
-        StdError::Unauthorized { .. } => {}
-        _ => panic!("Expected unauthorized"),
+fn get_log_attribute(resp: &HandleResponse, key: String) -> Option<String> {
+    for log in resp.log.iter() {
+        if log.key == key {
+            return Some(log.value.to_owned());
+        }
     }
 
-    // only the original creator can reset the counter
-    let auth_env = mock_env(&deps.api, "creator", &coins(2, "token"));
-    let msg = HandleMsg::Reset { count: 5 };
-    let _res: HandleResponse = handle(&mut deps, auth_env, msg).unwrap();
-
-    // should now be 5
-    let res = query(&mut deps, QueryMsg::GetCount {}).unwrap();
-    let value: CountResponse = from_binary(&res).unwrap();
-    assert_eq!(value.count, 5);
+    None
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -62,7 +62,7 @@ fn init_sign() {
     let env = mock_env("creator", &coins(1000, "earth"));
     let res = handle(&mut deps, env, msg);
     let sign_res = res.unwrap();
-    let signature = get_log_attribute(&sign_res, "signature").expect("No signature detected"); 
+    let signature = get_log_attribute(&sign_res, "signature").expect("No signature detected");
 
     let expected_signature = "e3eb2ff3403a0dbb55253dc2039995eaf4932d92b55c8422f69b5b5e1f0753c15581f9c53e3987db54d6f3f04d8c9f32407652758456411a984f55d8c1c6097a";
     assert_eq!(signature, expected_signature);


### PR DESCRIPTION
As I promised 
- I wrote the integration tests for that contract.
- I added the secp256k1::PrivateKey signature from the secret_toolkit. 

NOTE: At the moment the secret_toolkit has a method for **serialize**, but the vault want to use the [serialize_compressed](https://github.com/enigmampc/secret-vault/blob/1c4adee34aba7849531411f3994b95755eda7fe5/src/contract.rs#L55). If I add this method to the secret_toolkit, I can completely remove the sign.rs and there won't be any code duplication compered to secret_toolkit.

UPDATE: The new method for secret_toolkit detailed above implemented [here](https://github.com/enigmampc/secret-toolkit/pull/13).